### PR TITLE
Solution: 04 Reusable valid brand

### DIFF
--- a/src/01-branded-types/04-reusable-valid-brand.problem.ts
+++ b/src/01-branded-types/04-reusable-valid-brand.problem.ts
@@ -1,35 +1,35 @@
-import { it } from "vitest";
-import { Brand } from "../helpers/Brand";
+import { it } from 'vitest'
+import { Brand } from '../helpers/Brand'
 
-type Valid<T> = unknown;
+type Valid<T> = Brand<T, 'ValidPassword'>
 
 interface PasswordValues {
-  password: string;
-  confirmPassword: string;
+  password: string
+  confirmPassword: string
 }
 
 const validatePassword = (values: PasswordValues) => {
   if (values.password !== values.confirmPassword) {
-    throw new Error("Passwords do not match");
+    throw new Error('Passwords do not match')
   }
 
-  return values;
-};
+  return values as Valid<PasswordValues>
+}
 
 const createUserOnApi = (values: Valid<PasswordValues>) => {
   // Imagine this function creates the user on the API
-};
+}
 
-it("Should fail if you do not validate the values before calling createUserOnApi", () => {
+it('Should fail if you do not validate the values before calling createUserOnApi', () => {
   const onSubmitHandler = (values: PasswordValues) => {
     // @ts-expect-error
-    createUserOnApi(values);
-  };
-});
+    createUserOnApi(values)
+  }
+})
 
-it("Should succeed if you DO validate the values before calling createUserOnApi", () => {
+it('Should succeed if you DO validate the values before calling createUserOnApi', () => {
   const onSubmitHandler = (values: PasswordValues) => {
-    const validatedValues = validatePassword(values);
-    createUserOnApi(validatedValues);
-  };
-});
+    const validatedValues = validatePassword(values)
+    createUserOnApi(validatedValues)
+  }
+})


### PR DESCRIPTION
## My solution
```ts
type Valid<T> = Brand<T, 'ValidPassword'>
```

```
const validatePassword = (values: PasswordValues) => {
  if (values.password !== values.confirmPassword) {
    throw new Error('Passwords do not match')
  }

  return values as Valid<PasswordValues>
}
```

## Explanation
First, we have to make a password validator type helper. We can use `Brand` type helper to achieve this:
```ts
type Valid<T> = Brand<T, 'ValidPassword'>
```

And then we can apply this Valid value to the returned value of `validatePassword` so we tell our system that the password has been validated and has the right type.