### PR TITLE
Solution: 08 Add to window

### DIFF
--- a/src/02-globals/08-add-to-window.problem.ts
+++ b/src/02-globals/08-add-to-window.problem.ts
@@ -9,6 +9,11 @@ import { Equal, Expect } from "../helpers/type-utils";
  * 2. Inside declare global, you'll need to modify the Window
  * interface to add a makeGreeting function
  */
+declare global {
+  interface Window {
+    makeGreeting: () => string;
+  }
+}
 
 window.makeGreeting = () => "Hello, world!";
 


### PR DESCRIPTION
## My solution
```ts
declare global {
  interface Window {
    makeGreeting: () => string;
  }
}
```

## Explanation
To solve this problem, we have to apply declaration merging concept.
The `window` object has type of `Window` with a bunch of types declared. We can merge a new type by declare our implementation inside `declare global` and then call `interface Window`.

## Notes
Declaration merging only works for `interface`!!