### PR TITLE
Solution: 12 Type predicates with filter

### DIFF
--- a/src/03-type-predicates-assertion-functions/12-type-predicates-with-filter.problem.ts
+++ b/src/03-type-predicates-assertion-functions/12-type-predicates-with-filter.problem.ts
@@ -3,7 +3,9 @@ import { Equal, Expect } from "../helpers/type-utils";
 
 export const values = ["a", "b", undefined, "c", undefined];
 
-const filteredValues = values.filter((value) => Boolean(value));
+const filteredValues = values.filter((value): value is string =>
+  Boolean(value)
+);
 
 it("Should filter out the undefined values", () => {
   expect(filteredValues).toEqual(["a", "b", "c"]);


### PR DESCRIPTION
## My Solution
```ts
const filteredValues = values.filter((value): value is string =>
  Boolean(value)
);
```

## Explanation
To solve the `filter` problem, we can narrow the type by using type predicate through `is` keyword.

## Notes
Type predicate itself has to return a boolean. Also, we have to be careful because we can lie to type predicate