### PR TITLE
Solution: 14 Typescript worst error

### DIFF
--- a/src/03-type-predicates-assertion-functions/14-typescripts-worst-error.problem.ts
+++ b/src/03-type-predicates-assertion-functions/14-typescripts-worst-error.problem.ts
@@ -15,13 +15,13 @@ interface NormalUser extends User {
   role: "normal";
 }
 
-const assertUserIsAdmin = (
-  user: NormalUser | AdminUser,
-): asserts user is AdminUser => {
+function assertUserIsAdmin(
+  user: NormalUser | AdminUser
+): asserts user is AdminUser {
   if (user.role !== "admin") {
     throw new Error("Not an admin user");
   }
-};
+}
 
 it("Should throw an error when it encounters a normal user", () => {
   const user: NormalUser = {


### PR DESCRIPTION
## My solution
```ts
function assertUserIsAdmin(
  user: NormalUser | AdminUser
): asserts user is AdminUser {
  if (user.role !== "admin") {
    throw new Error("Not an admin user");
  }
}
```

## Explanation
The solution is by transforming the function from arrow function to normal function. But I still don't know why it happened, let's see what Matt says about this.

## Notes
Matt doesn't know too why it happens
Just a Typescript weird error moment 😂 