### PR TITLE
Solution: 15 Type predicates with generics

### DIFF
--- a/src/03-type-predicates-assertion-functions/15-type-predicates-with-generics.problem.ts
+++ b/src/03-type-predicates-assertion-functions/15-type-predicates-with-generics.problem.ts
@@ -7,12 +7,12 @@ import { Equal, Expect } from "../helpers/type-utils";
  * you can fix all the errors below.
  */
 interface DOMNodeExtractorConfig<T, Result> {
-  isNode: (node: unknown) => boolean;
+  isNode: (node: unknown) => node is T;
   transform: (node: T) => Result;
 }
 
 const createDOMNodeExtractor = <T, TResult>(
-  config: DOMNodeExtractorConfig<T, TResult>,
+  config: DOMNodeExtractorConfig<T, TResult>
 ) => {
   return (nodes: unknown[]): TResult[] => {
     return nodes.filter(config.isNode).map(config.transform);


### PR DESCRIPTION
## My solution
```ts
  isNode: (node: unknown) => node is T;
```

## Explanation
The solution is by transform the return value from `isNode` to type predicates, so we can get the right type inside our generic declaration.