### PR TITLE
Solution: 16 Brands and type predicates

### DIFF
--- a/src/03-type-predicates-assertion-functions/16-brands-and-type-predicates.problem.ts
+++ b/src/03-type-predicates-assertion-functions/16-brands-and-type-predicates.problem.ts
@@ -11,7 +11,9 @@ interface PasswordValues {
 /**
  * 💡 You'll need to change this function...
  */
-const isValidPassword = (values: PasswordValues) => {
+const isValidPassword = (
+  values: PasswordValues
+): values is Valid<PasswordValues> => {
   if (values.password !== values.confirmPassword) {
     return false;
   }


### PR DESCRIPTION
## My solution
```ts
const isValidPassword = (
  values: PasswordValues
): values is Valid<PasswordValues> => {
  if (values.password !== values.confirmPassword) {
    return false;
  }
  return true;
};
```

## Explanation
The problem is we need to find a way so inside the conditional statement, it recognizes the value is valid branded value. To solve this issue, we can add type predicates for the `isValidPassword` by adding this line:
```ts
: values is Valid<PasswordValues>
```
