### PR TITLE
Solution: 17.8 Classes as types and values

### DIFF
--- a/src/04-classes/17.8-classes-as-types-and-value.problem.ts
+++ b/src/04-classes/17.8-classes-as-types-and-value.problem.ts
@@ -8,7 +8,7 @@ class CustomError extends Error {
 }
 
 // How do we type the 'error' parameter?
-const handleCustomError = (error: unknown) => {
+const handleCustomError = (error: CustomError) => {
   console.error(error.code);
 
   type test = Expect<Equal<typeof error.code, number>>;


### PR DESCRIPTION
## My solution
```ts
const handleCustomError = (error: CustomError) => {
```

## Problem
To use `CustomError` class as type, we can call it directly by its name. It is a feature in Typescript to be able to call the class as type.