### PR TITLE
Solution: 18 Type predicates and classes

### DIFF
--- a/src/04-classes/18-type-predicates-and-classes.problem.ts
+++ b/src/04-classes/18-type-predicates-and-classes.problem.ts
@@ -5,10 +5,10 @@ class Form<TValues> {
 
   constructor(
     public values: TValues,
-    private validate: (values: TValues) => string | void,
+    private validate: (values: TValues) => string | void
   ) {}
 
-  isInvalid() {
+  isInvalid(): this is { error: string } {
     const result = this.validate(this.values);
 
     if (typeof result === "string") {
@@ -34,7 +34,7 @@ const form = new Form(
     if (!values.password) {
       return "Password is required";
     }
-  },
+  }
 );
 
 if (form.isInvalid()) {


### PR DESCRIPTION
## My solution
```ts
  isInvalid(): this is { error: string } {
```

## Explanation
To solve the problem of type predicates inside classes, we can use `this is Type` keyword. So if it is invalid, the code that goes after that will know the type of error will only be a `string`.

## Notes
We can make it has more complete type by adding `this is this`, so the type predicate will be like this;
`this is this & { error: string }`