### PR TITLE
Solution: 20 Type safe map

### DIFF
--- a/src/04-classes/20-type-safe-map.problem.ts
+++ b/src/04-classes/20-type-safe-map.problem.ts
@@ -18,10 +18,13 @@ class TypeSafeStringMap<TMap extends Record<string, string> = {}> {
     return this.map[key];
   }
 
-  set<K extends string>(key: K, value: string): unknown {
+  set<K extends string>(
+    key: K,
+    value: string
+  ): TypeSafeStringMap<Record<K | keyof TMap, string>> {
     (this.map[key] as any) = value;
 
-    return this;
+    return this as any;
   }
 }
 
@@ -33,7 +36,7 @@ const map = new TypeSafeStringMap()
 it("Should not allow getting values which do not exist", () => {
   map.get(
     // @ts-expect-error
-    "jim",
+    "jim"
   );
 });
 


### PR DESCRIPTION
## My solution
```ts
  set<K extends string>(
    key: K,
    value: string
  ): TypeSafeStringMap<Record<K | keyof TMap, string>> {
    (this.map[key] as any) = value;

    return this as any;
  }

```

## Explanation
In this exercise, we need to make our builder class to be type-safe. 
We can do this by adding this piece of code to type the setter:
```ts
 TypeSafeStringMap<Record<K | keyof TMap, string>>
```

By adding this, we append our new key to the existing keys in type domain.