### PR TITLE
Solution: 21 Importance of default generic

### DIFF
--- a/src/04-classes/21-importance-of-default-generic.problem.ts
+++ b/src/04-classes/21-importance-of-default-generic.problem.ts
@@ -7,7 +7,7 @@ import { expect, it } from "vitest";
  * Clue: it's somewhere inside class TypeSafeStringMap, and it's
  * on the type level - not the runtime level.
  */
-class TypeSafeStringMap<TMap extends Record<string, string>> {
+class TypeSafeStringMap<TMap extends Record<string, string> = {}> {
   private map: TMap;
   constructor() {
     this.map = {} as TMap;
@@ -19,7 +19,7 @@ class TypeSafeStringMap<TMap extends Record<string, string>> {
 
   set<K extends string>(
     key: K,
-    value: string,
+    value: string
   ): TypeSafeStringMap<TMap & Record<K, string>> {
     (this.map[key] as any) = value;
 
@@ -35,7 +35,7 @@ const map = new TypeSafeStringMap()
 it("Should not allow getting values which do not exist", () => {
   map.get(
     // @ts-expect-error
-    "jim",
+    "jim"
   );
 });
 


### PR DESCRIPTION
## My solution
```ts
class TypeSafeStringMap<TMap extends Record<string, string> = {}> {
```

## Explanation
We can solve the issue in this exercise by adding back the default value of generic.

## Notes 
This issue caused by the TS compiler will make `Record<string, string>` as the default value when we don't provide any default values. It will cause the union between `string | "whatever" | "values"`, end it will end up as `string`, it doesn't respect our literal string input.