### PR TITLE
Solution: 23 Extract external lib types

### DIFF
--- a/src/05-external-libraries/23-extract-external-lib-types.problem.ts
+++ b/src/05-external-libraries/23-extract-external-lib-types.problem.ts
@@ -6,9 +6,11 @@ import { Equal, Expect, ExpectExtends } from "../helpers/type-utils";
  * to extend the types. Extract the types below.
  */
 
-type ParametersOfFetchUser = unknown;
+type ParametersOfFetchUser = Parameters<typeof fetchUser>;
 
-type ReturnTypeOfFetchUserWithFullName = unknown;
+type ReturnTypeOfFetchUserWithFullName = Awaited<
+  ReturnType<typeof fetchUser>
+> & { fullName: string };
 
 export const fetchUserWithFullName = async (
   ...args: ParametersOfFetchUser
@@ -27,5 +29,5 @@ type tests = [
       { id: string; firstName: string; lastName: string; fullName: string },
       ReturnTypeOfFetchUserWithFullName
     >
-  >,
+  >
 ];


### PR DESCRIPTION
## My solution
```ts
type ParametersOfFetchUser = Parameters<typeof fetchUser>;

type ReturnTypeOfFetchUserWithFullName = Awaited<
  ReturnType<typeof fetchUser>
> & { fullName: string };
```

## Explanation
We need to extract 2 set of types in to solve this problem, the argument and return type of the `fetchUser`.
To extract the argument type of `fetchUser`, we can use `Parameters`.

While to extract the return type of `fetchUser`, we can use `ReturnType`. 
Since, it infers `Promise`, we can unwrap it by using `Awaited` and extend it with `fullName`.