### PR TITLE
Solution: 24 Lodash groupby

### DIFF
--- a/src/05-external-libraries/24-lodash-groupby.problem.ts
+++ b/src/05-external-libraries/24-lodash-groupby.problem.ts
@@ -1,4 +1,4 @@
-import _ from "lodash";
+import _, { List } from "lodash";
 import { expect, it } from "vitest";
 import { doNotExecute, Equal, Expect } from "../helpers/type-utils";
 
@@ -10,7 +10,9 @@ import { doNotExecute, Equal, Expect } from "../helpers/type-utils";
  * 2. Take a look at the typings for _.groupBy to
  * see if you can understand them.
  */
-const groupByAge = (array: unknown[]) => {
+const groupByAge = <T extends { name: string; age: number }>(
+  array: List<T>
+) => {
   const grouped = _.groupBy(array, "age");
 
   return grouped;

--- a/src/05-external-libraries/24-lodash-groupby.problem.ts
+++ b/src/05-external-libraries/24-lodash-groupby.problem.ts
@@ -10,9 +10,7 @@ import { doNotExecute, Equal, Expect } from "../helpers/type-utils";
  * 2. Take a look at the typings for _.groupBy to
  * see if you can understand them.
  */
-const groupByAge = <T extends { name: string; age: number }>(
-  array: List<T>
-) => {
+const groupByAge = <T extends { age: number }>(array: List<T>) => {
   const grouped = _.groupBy(array, "age");
 
   return grouped;


### PR DESCRIPTION
## My solution
```ts
const groupByAge = <T extends { name: string; age: number }>(
  array: List<T>
) => {
  const grouped = _.groupBy(array, "age");

  return grouped;
};
```

## Explanation
To solve the problem, we have to know the type that expected by `_.groupBy`, we can know by hover around the function.
![image](https://github.com/kentnathaniel/advanced-patterns-workshop/assets/31380193/03972721-2d74-4789-beed-d3e2eed9a163)

From there, we know the type is supposed to be `List<T>`.
Then we can inspect what `T` is supposed to be and after check the implementation, it doesn't have any restriction as long as it is a valid array member.

We want to group the object, so we can pass our `T` to match the object shape.