### PR TITLE
Solution: 25 Usage with express

### DIFF
--- a/src/05-external-libraries/25-usage-with-express.problem.ts
+++ b/src/05-external-libraries/25-usage-with-express.problem.ts
@@ -9,9 +9,9 @@ import { Equal, Expect } from "../helpers/type-utils";
 const app = express();
 
 const makeTypeSafeGet =
-  (
-    parser: (queryParams: Request["query"]) => unknown,
-    handler: RequestHandler
+  <TQuery extends { id: string }>(
+    parser: (queryParams: Request["query"]) => TQuery,
+    handler: RequestHandler<any, any, any, TQuery>
   ) =>
   (req: Request, res: Response, next: NextFunction) => {
     try {
@@ -21,7 +21,7 @@ const makeTypeSafeGet =
       return;
     }
 
-    return handler(req, res, next);
+    return handler(req as any, res, next);
   };
 
 const getUser = makeTypeSafeGet(


### PR DESCRIPTION
## My solution
```ts
const makeTypeSafeGet =
  <TQuery extends { id: string }>(
    parser: (queryParams: Request["query"]) => TQuery,
    handler: RequestHandler<any, any, any, TQuery>
  ) =>
	....
    return handler(req as any, res, next);
  };
```

## Explanation
In this case, we need a generic slot to infer the query. And then we can pass that generic `TQuery` to the return of parser and into 4th generic slot of `RequestHandler`.

For some reason, we have a type error even though everything is right.
![image](https://github.com/kentnathaniel/advanced-patterns-workshop/assets/31380193/692711f6-8d92-43ca-bebf-7651033d034e)

I had no idea what this happened, but Matt had given a clue I should do some assertion, so I put an assertion there.

## Notes
I should insert another generic, to make the `req` to be type-safe instead of doing assertion.
```ts
  (req: Request<any, any, any, TQuery>, res: Response, next: NextFunction) => {
```

Another thing, I should only extend `Request["query"]` for `TQuery`, so it will end up
```ts
  <TQuery extends Request["query"]>
```

Why? To make it more flexible and reusable for the function `makeTypeSafeGet`