### PR TITLE
Solution: 26 Usage with zod

### DIFF
--- a/src/05-external-libraries/26-usage-with-zod.problem.ts
+++ b/src/05-external-libraries/26-usage-with-zod.problem.ts
@@ -1,10 +1,10 @@
 import { expect, it } from "vitest";
-import { z } from "zod";
+import { ZodTypeDef, z } from "zod";
 
-const makeZodSafeFunction = (
-  schema: unknown,
-  func: (arg: unknown) => unknown
-) => {
+const makeZodSafeFunction = <TInput>(
+  schema: z.ZodSchema<any, ZodTypeDef, TInput>,
+  func: (arg: TInput) => any
+): ((arg: TInput) => any) => {
   return (arg: unknown) => {
     const result = schema.parse(arg);
     return func(result);

--- a/src/05-external-libraries/26-usage-with-zod.problem.ts
+++ b/src/05-external-libraries/26-usage-with-zod.problem.ts
@@ -1,11 +1,11 @@
 import { expect, it } from "vitest";
 import { ZodTypeDef, z } from "zod";
 
-const makeZodSafeFunction = <TInput>(
-  schema: z.ZodSchema<any, ZodTypeDef, TInput>,
-  func: (arg: TInput) => any
-): ((arg: TInput) => any) => {
-  return (arg: unknown) => {
+const makeZodSafeFunction = <TArg, TResult>(
+  schema: z.ZodSchema<TArg>,
+  func: (arg: TArg) => TResult
+) => {
+  return (arg: TArg) => {
     const result = schema.parse(arg);
     return func(result);
   };


### PR DESCRIPTION
## My solution
```ts
const makeZodSafeFunction = <TInput>(
  schema: z.ZodSchema<any, ZodTypeDef, TInput>,
  func: (arg: TInput) => any
): ((arg: TInput) => any) => {
```

## Explanation
For the solution, we need 1 generic slot to infer the input ( `TInput` ).

And then we can type our `schema` arg with `z.ZodSchema` ( just another alias for `z.zodType` ), 
which accept `Output` and `Input` generic.
We can use `any` for the `Output`, but for the input we can pass our generic `TInput`.

## Notes
My bad, actually I did slight mistake in the solution.
We can rename our generic to `TArg` and add another generic `TResult`.
And then we can type our schema with `z.Schema<TArg>`, so the `TArg` should be the result or byproduct of our schema.
`TResult` is a generic to make sure our result type-safe too.

```ts
const makeZodSafeFunction = <TArg, TResult>(
  schema: z.ZodSchema<TArg>,
  func: (arg: TInput) => TResult
) =>
```