### PR TITLE
Solution: 26.5 Override external lib types

### DIFF
--- a/src/05-external-libraries/26.5-declaration.my-solution.d.ts
+++ b/src/05-external-libraries/26.5-declaration.my-solution.d.ts
@@ -1,0 +1,6 @@
+declare module "fake-animation-lib" {
+  export function getAnimatingState():
+    | "before-animation"
+    | "animating"
+    | "after-animation";
+}


### PR DESCRIPTION
## My solution

Create a new declaration `d.ts` file with this content:
```ts
declare module "fake-animation-lib" {
  export function getAnimatingState():
    | "before-animation"
    | "animating"
    | "after-animation";
}
```

## Explanation
By create `d.ts` file, we say to TS, please read the type declaration in this file and use this instead as source of truth.