### PR TITLE
Solution: 27 Const annotations

### DIFF
--- a/src/06-identity-functions/27-const-annotations.problem.ts
+++ b/src/06-identity-functions/27-const-annotations.problem.ts
@@ -1,6 +1,6 @@
 import { Equal, Expect } from "../helpers/type-utils";
 
-export const asConst = <T>(t: T) => t;
+export const asConst = <const T>(t: T) => t;
 
 const fruits = asConst([
   {


### PR DESCRIPTION
## My solution
```ts
export const asConst = <const T>(t: T) => t;
```

## Explanation
We can add `const` keyword in the generic since TS 5.0, this will ensure the generic is `readonly` type.