### PR TITLE
Solution: 28 Constraints with const annotations

### DIFF
--- a/src/06-identity-functions/28-constraints-with-const-annotations.problem.ts
+++ b/src/06-identity-functions/28-constraints-with-const-annotations.problem.ts
@@ -1,7 +1,11 @@
 import { it } from "vitest";
 import { Equal, Expect } from "../helpers/type-utils";
 
-export const narrowFruits = <TFruits>(t: TFruits) => t;
+export const narrowFruits = <
+  const TFruits extends readonly { name: string; price: number }[]
+>(
+  t: TFruits
+) => t;
 
 const fruits = narrowFruits([
   {


### PR DESCRIPTION
## My solution
```ts
export const narrowFruits = <
  const TFruits extends readonly { name: string; price: number }[]
>(
  t: TFruits
) => t;
```

## Explanation
To solve this problem, we have to mark `TFruits` as constant by adding `const` keyword in front of it. And then the gotcha here, we can't normally extend it with a normal object `{ name: string; price: number }`, but we have to extend it with a readonly object


## Notes
Readonly type is really useful because not only we infer the type, but also we infer the literal value.