### PR TITLE
Solution: 29 Finite state machine

### DIFF
--- a/src/06-identity-functions/29-finite-state-machine.problem.ts
+++ b/src/06-identity-functions/29-finite-state-machine.problem.ts
@@ -1,4 +1,4 @@
-// import { F } from "ts-toolbelt";
+import { F } from "ts-toolbelt";
 
 /**
  * Clue: F.NoInfer is part of the solution!
@@ -7,7 +7,7 @@
  * to get it to work.
  */
 interface FSMConfig<TState extends string> {
-  initial: TState;
+  initial: F.NoInfer<TState>;
   states: Record<
     TState,
     {


### PR DESCRIPTION
## My solution
```ts
interface FSMConfig<TState extends string> {
  initial: F.NoInfer<TState>;
  states: Record<
    TState,
    {
      onEntry?: () => void;
    }
  >;
}
```

## Explanation
This is a really useful type helper to avoid inferring the wrong value, it's called `F.NoInfer` from `ts-toolbelt`.
We can add this type helper to the place where we don't want to infer the value.