### PR TITLE
Solution: 30 No generics on objects

### DIFF
--- a/src/06-identity-functions/30-no-generics-on-objects.problem.ts
+++ b/src/06-identity-functions/30-no-generics-on-objects.problem.ts
@@ -13,7 +13,16 @@
  * const config = makeConfigObj(config);
  */
 
-export const configObj = {
+type Config<TRoute extends string> = {
+  routes: TRoute[];
+  fetchers: Record<TRoute, () => {}>;
+};
+
+export const makeConfigObj = <TRoute extends string>(
+  config: Config<TRoute>
+) => {};
+
+export const configObj = makeConfigObj({
   routes: ["/", "/about", "/contact"],
   fetchers: {
     // @ts-expect-error
@@ -21,4 +30,4 @@ export const configObj = {
       return {};
     },
   },
-};
+});


### PR DESCRIPTION
## My solution
```ts
type Config<TRoute extends string> = {
  routes: TRoute[];
  fetchers: Record<TRoute, () => {}>;
};

export const makeConfigObj = <TRoute extends string>(
  config: Config<TRoute>
) => {};

export const configObj = makeConfigObj({
  routes: ["/", "/about", "/contact"],
  fetchers: {
    // @ts-expect-error
    "/does-not-exist": () => {
      return {};
    },
  },
});
```

## Explanation
This one is a really interesting problem. We can define our `configObj` type like this:

```ts
const configObj2: Config<"/" | "/about" | "/contact"> = {
  routes: ["/", "/about", "/contact"],
  fetchers: {
    // @ts-expect-error
    "/does-not-exist": () => {
      return {};
    },
  },
};
```

But this solution is really ugly since we have to declare the route twice, both in generic slot and routes declaration.
The more neat solution is by generating our `configObj` via `makeConfigObj` function and it will automatically add the generic inference for us.