### PR TITLE
Solution: 30.5 Reverse mapped types

### DIFF
--- a/src/06-identity-functions/30.5-reverse-mapped-types.problem.ts
+++ b/src/06-identity-functions/30.5-reverse-mapped-types.problem.ts
@@ -1,6 +1,8 @@
 import { Equal, Expect } from "../helpers/type-utils";
 
-export function makeEventHandlers(obj: unknown) {
+export function makeEventHandlers<TKeys extends string>(obj: {
+  [K in TKeys]: (name: K) => void;
+}) {
   return obj;
 }
 


### PR DESCRIPTION
## My solution
```ts
export function makeEventHandlers<TKeys extends string>(obj: {
  [K in TKeys]: (name: K) => void;
}) {
  return obj;
}
```

## Explanation
To solve this problem, we need to have 1 generic slot to infer the keys of our object. 
And then we can use indexed access type to map over the keys and use that key to constraint our `name` argument.

## Notes
Actually I got the idea slightly wrong, Matt wants to explain about this solution:
```ts
export function makeEventHandlers<T>(obj: {
  [K in keyof T]: (name: K) => void;
}) {
  return obj;
}
```

Where we can get generic `K` from generic `T` and then use that `K` to type the `name` argument. So, we can infer something inside another inference. This is a wild idea!!