### PR TITLE
Solution: 31 Merge dynamic object with global

### DIFF
--- a/src/07-challenges/31-merge-dynamic-object-with-global.problem.ts
+++ b/src/07-challenges/31-merge-dynamic-object-with-global.problem.ts
@@ -9,9 +9,15 @@ const addAllOfThisToWindow = {
 
 Object.assign(window, addAllOfThisToWindow);
 
+type AddAllOfThisToWindow = typeof addAllOfThisToWindow;
+
+declare global {
+  interface Window extends AddAllOfThisToWindow {}
+}
+
 type tests = [
   Expect<Equal<typeof window.add, (a: number, b: number) => number>>,
   Expect<Equal<typeof window.subtract, (a: number, b: number) => number>>,
   Expect<Equal<typeof window.multiply, (a: number, b: number) => number>>,
-  Expect<Equal<typeof window.divide, (a: number, b: number) => number>>,
+  Expect<Equal<typeof window.divide, (a: number, b: number) => number>>
 ];


### PR DESCRIPTION
## My solution
```ts
type AddAllOfThisToWindow = typeof addAllOfThisToWindow;

declare global {
  interface Window extends AddAllOfThisToWindow {}
}
```

## Explanation
We could extend our `Window` with our custom type to solve this problem. 
This is really neat and avoid the duplication in our code.