### PR TITLE
Solution: 32 Narrow with arrays

### DIFF
--- a/src/07-challenges/32-narrow-with-arrays.problem.ts
+++ b/src/07-challenges/32-narrow-with-arrays.problem.ts
@@ -5,9 +5,14 @@ interface Fruit {
   price: number;
 }
 
-export const wrapFruit = (fruits: unknown[]) => {
-  const getFruit = (name: unknown) => {
-    return fruits.find((fruit) => fruit.name === name);
+export const wrapFruit = <const TFruit extends { name: string; price: number }>(
+  fruits: TFruit[]
+) => {
+  const getFruit = <TName extends TFruit["name"]>(name: TName) => {
+    return fruits.find((fruit) => fruit.name === name) as Extract<
+      TFruit,
+      { name: TName }
+    >;
   };
 
   return {


### PR DESCRIPTION
## My solution
```ts
export const wrapFruit = <const TFruit extends { name: string; price: number }>(
  fruits: TFruit[]
) => {
  const getFruit = <TName extends TFruit["name"]>(name: TName) => {
    return fruits.find((fruit) => fruit.name === name) as Extract<
      TFruit,
      { name: TName }
    >;
  };

  return {
    getFruit,
  };
};
```

## Explanation
There's a lot going on here. But let me explain piece by piece.
So for the solution, first we have to constrain the array member to be readonly of `{name, price}` object.

```ts
export const wrapFruit = <const TFruit extends { name: string; price: number }>(
  fruits: TFruit[]
) 
```

This is kind of nice because we now can get the access to each member of fruit array. The next step we need to constrain our `getFruit` to only accept `name` from `TFruit`. We can add:

```ts
 const getFruit = <TName extends TFruit["name"]>(name: TName) => {
```

The last thing, we need to type our return value to match the expected result. We have to do assertion here since `find` function isn't that smart to infer the matched value.
For the assertion, we can use `Extract` to get the value from union that match our `name` key.

```ts
    return fruits.find((fruit) => fruit.name === name) as Extract<
      TFruit,
      { name: TName }
    >
```