### PR TITLE
Solution: 33 Zod with express

### DIFF
--- a/src/07-challenges/33-zod-with-express.problem.ts
+++ b/src/07-challenges/33-zod-with-express.problem.ts
@@ -3,13 +3,13 @@ import { it } from "vitest";
 import { z, ZodError } from "zod";
 import { Equal, Expect } from "../helpers/type-utils";
 
-const makeTypeSafeHandler = (
+const makeTypeSafeHandler = <TQuery = any, TBody = any>(
   config: {
-    query?: z.Schema;
-    body?: z.Schema;
+    query?: z.Schema<TQuery>;
+    body?: z.Schema<TBody>;
   },
-  handler: RequestHandler
-): RequestHandler => {
+  handler: RequestHandler<any, any, TBody, TQuery>
+): RequestHandler<any, any, TBody, TQuery> => {
   return (req, res, next) => {
     const { query, body } = req;
     if (config.query) {


### PR DESCRIPTION
## My solution
```ts
const makeTypeSafeHandler = <TQuery = any, TBody = any>(
  config: {
    query?: z.Schema<TQuery>;
    body?: z.Schema<TBody>;
  },
  handler: RequestHandler<any, any, TBody, TQuery>
): RequestHandler<any, any, TBody, TQuery> => {
```

## Explanation
This is a really interesting problem, I love this so much. Matt tested us with a real application of working with multiple external libraries, in this case zod and express.

The problem is how we get the type safe while working with zod and express. 
We need 2 generic slots to solve this problem, `TQuery` to infer the query shape and `TBody` to infer the body shape.
And then we can pass that `TQuery` and `TBody` to `z.Schema` generic slot to capture the shape of each.

And then, we can use that captured body and query to define `req.body` and `req.query` type by passing that to `RequestHandler` generic slot.